### PR TITLE
Allow compatibility with Cython 3.x

### DIFF
--- a/pytetgen/pytetgen.pyx
+++ b/pytetgen/pytetgen.pyx
@@ -1,3 +1,4 @@
+#!python
 # cython: language_level=2
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding: utf-8 -*-
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/pytetgen/pytetgen.pyx
+++ b/pytetgen/pytetgen.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 # -*- Mode: python; tab-width: 4; indent-tabs-mode:nil; coding: utf-8 -*-
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 # distutils: language=c++

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# cython: language_level=2
 # distutils: include_dirs = pytetgen
 # distutils: language=c++
 from distutils.core import setup
@@ -51,7 +50,7 @@ setup(	name = 'pytetgen',
         ext_modules=[
               Extension('pytetgen', 
                  sources=['pytetgen/tetgen.cxx','pytetgen/predicates.cxx','pytetgen/pytetgen.pyx'],
-                 compiler_directives={'language_level':3},
+                 compiler_directives={'language_level':2},
 		 include_dirs=[np.get_include()],
 		 extra_compile_args=['-g0','-O0','-DTETLIBRARY'],
                  language='c++'),

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# cython: language_level=2
 # distutils: include_dirs = pytetgen
 # distutils: language=c++
 from distutils.core import setup


### PR DESCRIPTION
This request is an attempt to fix Issue #9 as described in https://stackoverflow.com/questions/64932145/cython-compile-error-cannot-assign-type-double-to-int-using-mingw64-in-win. 
